### PR TITLE
Do not select same destination after deep link

### DIFF
--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/NavigationExtensions.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/NavigationExtensions.kt
@@ -171,7 +171,8 @@ private fun BottomNavigationView.setupDeepLinks(
             containerId
         )
         // Handle Intent
-        if (navHostFragment.navController.handleDeepLink(intent)) {
+        if (navHostFragment.navController.handleDeepLink(intent)
+           && selectedItemId != navHostFragment.navController.graph.id) {
             this.selectedItemId = navHostFragment.navController.graph.id
         }
     }


### PR DESCRIPTION
After handling the deep link intent, if we are already on the current graph, we should not reselect it. Doing so causes the current destination to be popped off the back stack.